### PR TITLE
使用go1.18 中的模板改善线程池代码调用体验

### DIFF
--- a/pool_test.go
+++ b/pool_test.go
@@ -1,4 +1,4 @@
-package mortar
+package pool
 
 import (
 	"sync"
@@ -11,13 +11,13 @@ var runTimes = 1000000
 
 var wg = sync.WaitGroup{}
 
-func demoTask(v ...interface{}) {
+func demoTask(_ any) {
 	for i := 0; i < 100; i++ {
 		atomic.AddInt64(&sum, 1)
 	}
 }
 
-func demoTask2(v ...interface{}) {
+func demoTask2(_ any) {
 	defer wg.Done()
 	for i := 0; i < 100; i++ {
 		atomic.AddInt64(&sum, 1)
@@ -26,17 +26,17 @@ func demoTask2(v ...interface{}) {
 
 func BenchmarkGoroutine(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		go demoTask()
+		go demoTask(nil)
 	}
 }
 
 func BenchmarkPut(b *testing.B) {
-	pool, err := NewPool(10)
+	pool, err := NewPool[any](10)
 	if err != nil {
 		b.Error(err)
 	}
 
-	task := &Task{
+	task := &Task[any]{
 		Handler: demoTask,
 	}
 
@@ -48,18 +48,18 @@ func BenchmarkPut(b *testing.B) {
 func BenchmarkGoroutineTimelife(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		wg.Add(1)
-		go demoTask2()
+		go demoTask2(nil)
 	}
 	wg.Wait()
 }
 
 func BenchmarkPutTimelife(b *testing.B) {
-	pool, err := NewPool(10)
+	pool, err := NewPool[any](10)
 	if err != nil {
 		b.Error(err)
 	}
 
-	task := &Task{
+	task := &Task[any]{
 		Handler: demoTask2,
 	}
 
@@ -74,17 +74,17 @@ func BenchmarkPutTimelife(b *testing.B) {
 func BenchmarkGoroutineSetTimes(b *testing.B) {
 
 	for i := 0; i < runTimes; i++ {
-		go demoTask()
+		go demoTask(nil)
 	}
 }
 
 func BenchmarkPoolPutSetTimes(b *testing.B) {
-	pool, err := NewPool(20)
+	pool, err := NewPool[any](20)
 	if err != nil {
 		b.Error(err)
 	}
 
-	task := &Task{
+	task := &Task[any]{
 		Handler: demoTask,
 	}
 
@@ -97,18 +97,18 @@ func BenchmarkGoroutineTimeLifeSetTimes(b *testing.B) {
 
 	for i := 0; i < runTimes; i++ {
 		wg.Add(1)
-		go demoTask2()
+		go demoTask2(nil)
 	}
 	wg.Wait()
 }
 
 func BenchmarkPoolTimeLifeSetTimes(b *testing.B) {
-	pool, err := NewPool(20)
+	pool, err := NewPool[any](20)
 	if err != nil {
 		b.Error(err)
 	}
 
-	task := &Task{
+	task := &Task[any]{
 		Handler: demoTask2,
 	}
 


### PR DESCRIPTION
我是初学者，对空接口什么的不是很熟悉，一开始被这个困扰了半天，没法直接用代码
后面就想改进下代码调用体验

具体方法是修改
Task[T any]
Pool[T any]
NewPool[T any]
这三个全加上泛型，泛型类型是具体pool中每个线程调用的函数的参数

这样就不需要写调用函数的时候添加 interface{}转调用的函数的参数类型 类型断言了，方便点
而且也支持单个参数的调用函数了
也可以不直接写函数了，调用已有的函数就行
如果需要可变参数的话自行写[]any数组
如果需要多参数的话写struct就行